### PR TITLE
Non Diffusion Dithering: Bugfix & Enhancements

### DIFF
--- a/Filterpedia/customFilters/DitherBayer.cikernel
+++ b/Filterpedia/customFilters/DitherBayer.cikernel
@@ -1,40 +1,334 @@
-//
-//  DitherBayer.cikernel
-//  Filterpedia
-//
-//  Created by African Swift on 09/02/2016.
-//  Copyright © 2016 Simon Gladman. All rights reserved.
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>
-//
-//
-// Ordered Dithering:
-//      Non Diffusion Dithering (i.e. specifically no diffusion of errors).
-//
-// Algorithm:
-//      Bayer Matrix (2x2, 3x3, 4x4 and 8x8)
-//
-// Reference:
-//      https://en.wikipedia.org/wiki/Ordered_dithering
-//
-// Color Palettes:
-//      1) Binary:     Black 0x00 and white 0xFF using only the red component.
-//      2) 3 Bit RGB:  All three components converted to either 0x00 or 0xFF.
-//
-// Current Limitations:
-//      1) Palette limitation (see above)
-//      2) Transparency pixels not specifically excluded, however alpha values are unaltered.
+    //
+    //  DitherBayer.cikernel
+    //  Filterpedia
+    //
+    //  Created by African Swift on 09/02/2016.
+    //  Copyright © 2016 Simon Gladman. All rights reserved.
+    //
+    //  This program is free software: you can redistribute it and/or modify
+    //  it under the terms of the GNU General Public License as published by
+    //  the Free Software Foundation, either version 3 of the License, or
+    //  (at your option) any later version.
+    //
+    //  This program is distributed in the hope that it will be useful,
+    //  but WITHOUT ANY WARRANTY; without even the implied warranty of
+    //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    //  GNU General Public License for more details.
+    //
+    //  You should have received a copy of the GNU General Public License
+    //  along with this program.  If not, see <http://www.gnu.org/licenses/>
+    //
+    //
+    // Ordered Dithering:
+    //      Non Diffusion Dithering (i.e. specifically no diffusion of errors).
+    //
+    // Algorithm:
+    //      Bayer Matrix (2x2, 3x3, 4x4 and 8x8)
+    //
+    // Reference:
+    //      https://en.wikipedia.org/wiki/Ordered_dithering
+    //
+    // Color Palettes:
+    //      1) Binary:  Black 0x00 and white 0xFF using only the red component.
+    //      2) Commodore 64
+    //      3) Vic-20
+    //      4) Apple II
+    //      5) ZX Spectrum Bright
+    //      6) ZX Spoectrum Dim
+    //      7) RGB
+
+vec3 binary(vec3 incolor) {
+    
+    float red = incolor.r > 0.5 ? 1.0 : 0.0;
+    return vec3(red, red, red);
+}
+
+vec3 zxSpectrumDim(vec3 incolor) {
+    
+    vec3 rgb1 = vec3(0.000000, 0.000000, 0.000000);
+    vec3 rgb2 = vec3(0.000000, 0.000000, 0.803922);
+    vec3 rgb3 = vec3(0.803922, 0.000000, 0.000000);
+    vec3 rgb4 = vec3(0.803922, 0.000000, 0.803922);
+    vec3 rgb5 = vec3(0.000000, 0.803922, 0.000000);
+    vec3 rgb6 = vec3(0.000000, 0.803922, 0.803922);
+    vec3 rgb7 = vec3(0.803922, 0.803922, 0.000000);
+    vec3 rgb8 = vec3(0.803922, 0.803922, 0.803922);
+    
+    float dist = distance(incolor, rgb1);
+    vec3 color = rgb1;
+    
+    float nextDist = distance(incolor, rgb2);
+    if (nextDist < dist) { dist = nextDist; color = rgb2; }
+    
+    nextDist = distance(incolor, rgb3);
+    if (nextDist < dist) { dist = nextDist; color = rgb3; }
+    
+    nextDist = distance(incolor, rgb4);
+    if (nextDist < dist) { dist = nextDist; color = rgb4; }
+    
+    nextDist = distance(incolor, rgb5);
+    if (nextDist < dist) { dist = nextDist; color = rgb5; }
+    
+    nextDist = distance(incolor, rgb6);
+    if (nextDist < dist) { dist = nextDist; color = rgb6; }
+    
+    nextDist = distance(incolor, rgb7);
+    if (nextDist < dist) { dist = nextDist; color = rgb7; }
+    
+    nextDist = distance(incolor, rgb8);
+    if (nextDist < dist) { dist = nextDist; color = rgb8; }
+    
+    return color;
+}
+
+vec3 zxSpectrumBright(vec3 incolor) {
+    
+    vec3 rgb1 = vec3(0.000000, 0.000000, 0.000000);
+    vec3 rgb2 = vec3(0.000000, 0.000000, 1.000000);
+    vec3 rgb3 = vec3(1.000000, 0.000000, 0.000000);
+    vec3 rgb4 = vec3(1.000000, 0.000000, 1.000000);
+    vec3 rgb5 = vec3(0.000000, 1.000000, 0.000000);
+    vec3 rgb6 = vec3(0.000000, 1.000000, 1.000000);
+    vec3 rgb7 = vec3(1.000000, 1.000000, 0.000000);
+    vec3 rgb8 = vec3(1.000000, 1.000000, 1.000000);
+    
+    float dist = distance(incolor, rgb1);
+    vec3 color = rgb1;
+    
+    float nextDist = distance(incolor, rgb2);
+    if (nextDist < dist) { dist = nextDist; color = rgb2; }
+    
+    nextDist = distance(incolor, rgb3);
+    if (nextDist < dist) { dist = nextDist; color = rgb3; }
+    
+    nextDist = distance(incolor, rgb4);
+    if (nextDist < dist) { dist = nextDist; color = rgb4; }
+    
+    nextDist = distance(incolor, rgb5);
+    if (nextDist < dist) { dist = nextDist; color = rgb5; }
+    
+    nextDist = distance(incolor, rgb6);
+    if (nextDist < dist) { dist = nextDist; color = rgb6; }
+    
+    nextDist = distance(incolor, rgb7);
+    if (nextDist < dist) { dist = nextDist; color = rgb7; }
+    
+    nextDist = distance(incolor, rgb8);
+    if (nextDist < dist) { dist = nextDist; color = rgb8; }
+    
+    return color;
+}
+
+vec3 appleII(vec3 incolor) {
+    
+    vec3 rgb1 = vec3(0.000000, 0.000000, 0.000000);
+    vec3 rgb2 = vec3(0.447059, 0.149020, 0.250980);
+    vec3 rgb3 = vec3(0.250980, 0.200000, 0.498039);
+    vec3 rgb4 = vec3(0.894118, 0.203922, 0.996078);
+    vec3 rgb5 = vec3(0.054902, 0.349020, 0.250980);
+    vec3 rgb6 = vec3(0.501961, 0.501961, 0.501961);
+    vec3 rgb7 = vec3(0.105882, 0.603922, 0.996078);
+    vec3 rgb8 = vec3(0.749020, 0.701961, 1.000000);
+    vec3 rgb9 = vec3(0.250980, 0.298039, 0.000000);
+    vec3 rgb10 = vec3(0.894118, 0.396078, 0.003922);
+    vec3 rgb11 = vec3(0.501961, 0.501961, 0.501961);
+    vec3 rgb12 = vec3(0.945098, 0.650980, 0.749020);
+    vec3 rgb13 = vec3(0.105882, 0.796078, 0.003922);
+    vec3 rgb14 = vec3(0.749020, 0.800000, 0.501961);
+    vec3 rgb15 = vec3(0.552941, 0.850980, 0.749020);
+    vec3 rgb16 = vec3(1.000000, 1.000000, 1.000000);
+    
+    float dist = distance(incolor, rgb1);
+    vec3 color = rgb1;
+    
+    float nextDist = distance(incolor, rgb2);
+    if (nextDist < dist) { dist = nextDist; color = rgb2; }
+    
+    nextDist = distance(incolor, rgb3);
+    if (nextDist < dist) { dist = nextDist; color = rgb3; }
+    
+    nextDist = distance(incolor, rgb4);
+    if (nextDist < dist) { dist = nextDist; color = rgb4; }
+    
+    nextDist = distance(incolor, rgb5);
+    if (nextDist < dist) { dist = nextDist; color = rgb5; }
+    
+    nextDist = distance(incolor, rgb6);
+    if (nextDist < dist) { dist = nextDist; color = rgb6; }
+    
+    nextDist = distance(incolor, rgb7);
+    if (nextDist < dist) { dist = nextDist; color = rgb7; }
+    
+    nextDist = distance(incolor, rgb8);
+    if (nextDist < dist) { dist = nextDist; color = rgb8; }
+    
+    nextDist = distance(incolor, rgb9);
+    if (nextDist < dist) { dist = nextDist; color = rgb9; }
+    
+    nextDist = distance(incolor, rgb10);
+    if (nextDist < dist) { dist = nextDist; color = rgb10; }
+    
+    nextDist = distance(incolor, rgb11);
+    if (nextDist < dist) { dist = nextDist; color = rgb11; }
+    
+    nextDist = distance(incolor, rgb12);
+    if (nextDist < dist) { dist = nextDist; color = rgb12; }
+    
+    nextDist = distance(incolor, rgb13);
+    if (nextDist < dist) { dist = nextDist; color = rgb13; }
+    
+    nextDist = distance(incolor, rgb14);
+    if (nextDist < dist) { dist = nextDist; color = rgb14; }
+    
+    nextDist = distance(incolor, rgb15);
+    if (nextDist < dist) { dist = nextDist; color = rgb15; }
+    
+    nextDist = distance(incolor, rgb16);
+    if (nextDist < dist) { dist = nextDist; color = rgb16; }
+    
+    return color;
+}
+
+vec3 vic20(vec3 incolor) {
+    
+    vec3 rgb1 = vec3(0.000000, 0.000000, 0.000000);
+    vec3 rgb2 = vec3(1.000000, 1.000000, 1.000000);
+    vec3 rgb3 = vec3(0.552941, 0.243137, 0.215686);
+    vec3 rgb4 = vec3(0.447059, 0.756863, 0.784314);
+    vec3 rgb5 = vec3(0.501961, 0.203922, 0.545098);
+    vec3 rgb6 = vec3(0.333333, 0.627451, 0.286275);
+    vec3 rgb7 = vec3(0.250980, 0.192157, 0.552941);
+    vec3 rgb8 = vec3(0.666667, 0.725490, 0.364706);
+    vec3 rgb9 = vec3(0.545098, 0.329412, 0.160784);
+    vec3 rgb10 = vec3(0.835294, 0.623529, 0.454902);
+    vec3 rgb11 = vec3(0.721569, 0.411765, 0.384314);
+    vec3 rgb12 = vec3(0.529412, 0.839216, 0.866667);
+    vec3 rgb13 = vec3(0.666667, 0.372549, 0.713725);
+    vec3 rgb14 = vec3(0.580392, 0.878431, 0.537255);
+    vec3 rgb15 = vec3(0.501961, 0.443137, 0.800000);
+    vec3 rgb16 = vec3(0.749020, 0.807843, 0.447059);
+    
+    float dist = distance(incolor, rgb1);
+    vec3 color = rgb1;
+    
+    float nextDist = distance(incolor, rgb2);
+    if (nextDist < dist) { dist = nextDist; color = rgb2; }
+    
+    nextDist = distance(incolor, rgb3);
+    if (nextDist < dist) { dist = nextDist; color = rgb3; }
+    
+    nextDist = distance(incolor, rgb4);
+    if (nextDist < dist) { dist = nextDist; color = rgb4; }
+    
+    nextDist = distance(incolor, rgb5);
+    if (nextDist < dist) { dist = nextDist; color = rgb5; }
+    
+    nextDist = distance(incolor, rgb6);
+    if (nextDist < dist) { dist = nextDist; color = rgb6; }
+    
+    nextDist = distance(incolor, rgb7);
+    if (nextDist < dist) { dist = nextDist; color = rgb7; }
+    
+    nextDist = distance(incolor, rgb8);
+    if (nextDist < dist) { dist = nextDist; color = rgb8; }
+    
+    nextDist = distance(incolor, rgb9);
+    if (nextDist < dist) { dist = nextDist; color = rgb9; }
+    
+    nextDist = distance(incolor, rgb10);
+    if (nextDist < dist) { dist = nextDist; color = rgb10; }
+    
+    nextDist = distance(incolor, rgb11);
+    if (nextDist < dist) { dist = nextDist; color = rgb11; }
+    
+    nextDist = distance(incolor, rgb12);
+    if (nextDist < dist) { dist = nextDist; color = rgb12; }
+    
+    nextDist = distance(incolor, rgb13);
+    if (nextDist < dist) { dist = nextDist; color = rgb13; }
+    
+    nextDist = distance(incolor, rgb14);
+    if (nextDist < dist) { dist = nextDist; color = rgb14; }
+    
+    nextDist = distance(incolor, rgb15);
+    if (nextDist < dist) { dist = nextDist; color = rgb15; }
+    
+    nextDist = distance(incolor, rgb16);
+    if (nextDist < dist) { dist = nextDist; color = rgb16; }
+    
+    return color;
+}
+
+vec3 commodore64(vec3 incolor) {
+    
+    vec3 rgb1 = vec3(0.000000, 0.000000, 0.000000);
+    vec3 rgb2 = vec3(1.000000, 1.000000, 1.000000);
+    vec3 rgb3 = vec3(0.533333, 0.223529, 0.196078);
+    vec3 rgb4 = vec3(0.403922, 0.713725, 0.741176);
+    vec3 rgb5 = vec3(0.545098, 0.247059, 0.588235);
+    vec3 rgb6 = vec3(0.333333, 0.627451, 0.286275);
+    vec3 rgb7 = vec3(0.250980, 0.192157, 0.552941);
+    vec3 rgb8 = vec3(0.749020, 0.807843, 0.447059);
+    vec3 rgb9 = vec3(0.545098, 0.329412, 0.160784);
+    vec3 rgb10 = vec3(0.341176, 0.258824, 0.000000);
+    vec3 rgb11 = vec3(0.721569, 0.411765, 0.384314);
+    vec3 rgb12 = vec3(0.313725, 0.313725, 0.313725);
+    vec3 rgb13 = vec3(0.470588, 0.470588, 0.470588);
+    vec3 rgb14 = vec3(0.580392, 0.878431, 0.537255);
+    vec3 rgb15 = vec3(0.470588, 0.411765, 0.768627);
+    vec3 rgb16 = vec3(0.623529, 0.623529, 0.623529);
+    
+    float dist = distance(incolor, rgb1);
+    vec3 color = rgb1;
+    
+    float nextDist = distance(incolor, rgb2);
+    if (nextDist < dist) { dist = nextDist; color = rgb2; }
+    
+    nextDist = distance(incolor, rgb3);
+    if (nextDist < dist) { dist = nextDist; color = rgb3; }
+    
+    nextDist = distance(incolor, rgb4);
+    if (nextDist < dist) { dist = nextDist; color = rgb4; }
+    
+    nextDist = distance(incolor, rgb5);
+    if (nextDist < dist) { dist = nextDist; color = rgb5; }
+    
+    nextDist = distance(incolor, rgb6);
+    if (nextDist < dist) { dist = nextDist; color = rgb6; }
+    
+    nextDist = distance(incolor, rgb7);
+    if (nextDist < dist) { dist = nextDist; color = rgb7; }
+    
+    nextDist = distance(incolor, rgb8);
+    if (nextDist < dist) { dist = nextDist; color = rgb8; }
+    
+    nextDist = distance(incolor, rgb9);
+    if (nextDist < dist) { dist = nextDist; color = rgb9; }
+    
+    nextDist = distance(incolor, rgb10);
+    if (nextDist < dist) { dist = nextDist; color = rgb10; }
+    
+    nextDist = distance(incolor, rgb11);
+    if (nextDist < dist) { dist = nextDist; color = rgb11; }
+    
+    nextDist = distance(incolor, rgb12);
+    if (nextDist < dist) { dist = nextDist; color = rgb12; }
+    
+    nextDist = distance(incolor, rgb13);
+    if (nextDist < dist) { dist = nextDist; color = rgb13; }
+    
+    nextDist = distance(incolor, rgb14);
+    if (nextDist < dist) { dist = nextDist; color = rgb14; }
+    
+    nextDist = distance(incolor, rgb15);
+    if (nextDist < dist) { dist = nextDist; color = rgb15; }
+    
+    nextDist = distance(incolor, rgb16);
+    if (nextDist < dist) { dist = nextDist; color = rgb16; }
+    
+    return color;
+}
+
 
 
 float orderedDither2x2(float colorin, float bx, float by, float errorIntensity)
@@ -50,7 +344,7 @@ float orderedDither2x2(float colorin, float bx, float by, float errorIntensity)
         if (px == 0) { error = 4.0 / 5.0; }
         if (px == 1) { error = 2.0 / 5.0; }
     }
-    return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity)) > 0.5 ? 1.0 : 0.0;
+    return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity));
 }
 
 float orderedDither3x3(float colorin, float bx, float by, float errorIntensity)
@@ -73,7 +367,7 @@ float orderedDither3x3(float colorin, float bx, float by, float errorIntensity)
         if (px == 1) { error = 8.0 / 10.0; }
         if (px == 2) { error = 5.0 / 10.0; }
     }
-    return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity)) > 0.5 ? 1.0 : 0.0;
+    return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity));
 }
 
 float orderedDither4x4(float colorin, float bx, float by, float errorIntensity)
@@ -105,7 +399,7 @@ float orderedDither4x4(float colorin, float bx, float by, float errorIntensity)
         if (px == 2) { error = 14.0 / 17.0; }
         if (px == 3) { error = 6.0 / 17.0; }
     }
-return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity)) > 0.5 ? 1.0 : 0.0;
+    return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity));
 }
 
 float orderedDither8x8(float colorin, float bx, float by, float errorIntensity)
@@ -193,40 +487,50 @@ float orderedDither8x8(float colorin, float bx, float by, float errorIntensity)
         if (px == 6) { error = 38.0 / 65.0; }
         if (px == 7) { error = 22.0 / 65.0; }
     }
-    return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity)) > 0.5 ? 1.0 : 0.0;
+    return colorin * (error * 2.0 * errorIntensity + (1.0 - errorIntensity));
 }
 
 kernel vec4 ditherBayer(__sample image, float intensity, float matrix, float palette)
 {
     vec4 pixel = sample(image, samplerCoord(image));
-    float px = mod(samplerCoord(image).x, 4.0);
-    float py = mod(samplerCoord(image).y, 4.0);
-
-    float red = palette < 1.0 ? pixel.r : pixel.r;
-    float green = palette < 1.0 ? pixel.r : pixel.g;
-    float blue = palette < 1.0 ? pixel.r : pixel.b;
-
-    if (matrix >= 2.0 && matrix < 3.0) {
+    int msize = int(matrix);
+    
+    float px = mod(samplerCoord(image).x, msize >= 5 ? float(8.0) : float(msize));
+    float py = mod(samplerCoord(image).y, msize >= 5 ? float(8.0) : float(msize));
+    
+    float red = pixel.r;
+    float green = pixel.g;
+    float blue = pixel.b;
+    
+    if (msize == 2) {
         pixel.r = orderedDither2x2(red, px, py, intensity);
         pixel.g = orderedDither2x2(green, px, py, intensity);
         pixel.b = orderedDither2x2(blue, px, py, intensity);
     }
-
-    if (matrix >= 3.0 && matrix < 4.0) {
+    
+    if (msize == 3) {
         pixel.r = orderedDither3x3(red, px, py, intensity);
         pixel.g = orderedDither3x3(green, px, py, intensity);
         pixel.b = orderedDither3x3(blue, px, py, intensity);
     }
-
-    if (matrix >= 4.0 && matrix < 5.0) {
+    
+    if (msize == 4) {
         pixel.r = orderedDither4x4(red, px, py, intensity);
         pixel.g = orderedDither4x4(green, px, py, intensity);
         pixel.b = orderedDither4x4(blue, px, py, intensity);
     }
-    if (matrix > 5.0) {
+    if (msize >= 5) {
         pixel.r = orderedDither8x8(red, px, py, intensity);
         pixel.g = orderedDither8x8(green, px, py, intensity);
         pixel.b = orderedDither8x8(blue, px, py, intensity);
     }
+    
+    if (int(palette) == 0) { return vec4(binary(vec3(pixel.r, pixel.g, pixel.b)), pixel.a); }
+    if (int(palette) == 1) { return vec4(commodore64(vec3(pixel.r, pixel.g, pixel.b)), pixel.a); }
+    if (int(palette) == 2) { return vec4(vic20(vec3(pixel.r, pixel.g, pixel.b)), pixel.a); }
+    if (int(palette) == 3) { return vec4(appleII(vec3(pixel.r, pixel.g, pixel.b)), pixel.a); }
+    if (int(palette) == 4) { return vec4(zxSpectrumBright(vec3(pixel.r, pixel.g, pixel.b)), pixel.a); }
+    if (int(palette) == 5) { return vec4(zxSpectrumDim(vec3(pixel.r, pixel.g, pixel.b)), pixel.a); }
+    
     return pixel;
 }

--- a/Filterpedia/customFilters/ThirdPartyFilters.swift
+++ b/Filterpedia/customFilters/ThirdPartyFilters.swift
@@ -50,12 +50,12 @@ class BayerDitherFilter: CIFilter
                 kCIAttributeType: kCIAttributeTypeScalar],
             "inputPalette": [kCIAttributeIdentity: 0,
                 kCIAttributeClass: "NSNumber",
-                kCIAttributeDescription: "Palette: 0 = Black / White, 1 = 3 Bit RGB",
+                kCIAttributeDescription: "Palette: 0 = Binary, 1 = Commodore 64, 2 = Vic-20, 3 = Apple II, 4 = ZX Spectrum Bright, 5 = ZX Spectrum Dim, 6 = RGB",
                 kCIAttributeDefault: 0.0,
                 kCIAttributeDisplayName: "Palette",
                 kCIAttributeMin: 0,
                 kCIAttributeSliderMin: 0,
-                kCIAttributeSliderMax: 1,
+                kCIAttributeSliderMax: 6,
                 kCIAttributeType: kCIAttributeTypeScalar]]
     }
     


### PR DESCRIPTION
Bug: (Incorrect mod used)
Affected 2x2, 3x3 and 8x8 (only 4x4 work as expected)

Enhancements: (Color Palettes extended)
 - Black 0x00 and white 0xFF using only the red component.
 - Commodore 64
 - Vic-20
 - Apple II
 - ZX Spectrum Bright
 - ZX Spectrum Dim
 - RGB